### PR TITLE
Add NotImplementedError for MLfit.model_guess when model type is not supported

### DIFF
--- a/pyLIMA/fits/ML_fit.py
+++ b/pyLIMA/fits/ML_fit.py
@@ -382,25 +382,31 @@ class MLfit(object):
                         pyLIMA.priors.guess.initial_guess_PSPL(
                             self.model.event)
 
-                if self.model.model_type() == 'FSPL':
+                elif self.model.model_type() == 'FSPL':
                     guess_paczynski_parameters, f_source = \
                         pyLIMA.priors.guess.initial_guess_FSPL(
                             self.model.event)
 
-                if self.model.model_type() == 'FSPLee':
+                elif self.model.model_type() == 'FSPLee':
                     guess_paczynski_parameters, f_source = \
                         pyLIMA.priors.guess.initial_guess_FSPL(
                             self.model.event)
 
-                if self.model.model_type() == 'FSPLarge':
+                elif self.model.model_type() == 'FSPLarge':
                     guess_paczynski_parameters, f_source = \
                         pyLIMA.priors.guess.initial_guess_FSPLarge(
                             self.model.event)
 
-                if self.model.model_type() == 'DSPL':
+                elif self.model.model_type() == 'DSPL':
                     guess_paczynski_parameters, f_source = \
                         pyLIMA.priors.guess.initial_guess_DSPL(
                             self.model.event)
+                
+                else:
+                    raise NotImplementedError(
+                        "Guessing initial parameters for "
+                        f"{self.model.model_type} is not yet supported."
+                    )
 
                 if 'theta_E' in self.fit_parameters.keys():
                     guess_paczynski_parameters = guess_paczynski_parameters + [1.0]

--- a/pyLIMA/fits/ML_fit.py
+++ b/pyLIMA/fits/ML_fit.py
@@ -405,7 +405,8 @@ class MLfit(object):
                 else:
                     raise NotImplementedError(
                         "Guessing initial parameters for "
-                        f"{self.model.model_type} is not yet supported."
+                        f"{self.model.model_type} is not yet supported. "
+                        "This model requires manually setting initial parameters."
                     )
 
                 if 'theta_E' in self.fit_parameters.keys():


### PR DESCRIPTION
This fixes a bug when you attempt fit without setting initial parameters for unsupported ulens models. Currently the behavior will fail with UnboundLocalError (because the variable `guess_paczynski_parameters` is not set but is later used).

Instead, a NotImplementedError is raised telling the user the ulens model is not supported for guessing init parameters.