### PR TITLE
Move all imports of plotting libraries into function scope

### DIFF
--- a/pyLIMA/fits/DEMC_fit.py
+++ b/pyLIMA/fits/DEMC_fit.py
@@ -4,7 +4,6 @@ import time as python_time
 import emcee
 import numpy as np
 from pyLIMA.fits.ML_fit import MLfit
-from pyLIMA.outputs import pyLIMA_plots
 from pyLIMA.priors import parameters_priors
 
 
@@ -142,7 +141,7 @@ class DEMCfit(MLfit):
                             'DEMC_chains': DEMC_chains, 'fit_time': computation_time}
 
     def fit_outputs(self):
-
+        from pyLIMA.outputs import pyLIMA_plots
         pyLIMA_plots.plot_lightcurves(self.model, self.fit_results['best_model'])
         pyLIMA_plots.plot_geometry(self.model, self.fit_results['best_model'])
 

--- a/pyLIMA/fits/ML_fit.py
+++ b/pyLIMA/fits/ML_fit.py
@@ -4,8 +4,6 @@ from multiprocessing import Manager
 
 import numpy as np
 import pyLIMA.fits.objective_functions as objective_functions
-from bokeh.layouts import gridplot
-from bokeh.plotting import output_file, save
 from pyLIMA.priors import parameters_boundaries
 from pyLIMA.priors import parameters_priors
 
@@ -1254,6 +1252,8 @@ class MLfit(object):
         implemented yet)
         bokeh_figure : bokehh.fig, a bokeh.figure containing all the above
         """
+        from bokeh.layouts import gridplot
+        from bokeh.plotting import output_file, save
         from pyLIMA.outputs import pyLIMA_plots
 
         matplotlib_lightcurves = None

--- a/pyLIMA/outputs/pyLIMA_plots.py
+++ b/pyLIMA/outputs/pyLIMA_plots.py
@@ -5,7 +5,6 @@ import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pyLIMA.fits.objective_functions
-import pygtc
 from bokeh.layouts import gridplot
 from bokeh.models import Arrow, OpenHead
 from bokeh.models import BasicTickFormatter
@@ -1188,6 +1187,7 @@ def plot_residuals(figure_axe, microlensing_model, model_parameters, bokeh_plot=
 
 
 def plot_distribution(samples, parameters_names=None, bokeh_plot=None):
+    import pygtc
     names = [str(i) for i in range(len(parameters_names))]
     try:
         GTC = pygtc.plotGTC(chains=[samples], sigmaContourLevels=True, paramNames=names,


### PR DESCRIPTION
This change saves 0.7 seconds in various patterns of importing pyLIMA. I agree the impact is very negligible. It is nice to have if the changes are not very disruptive to development.


Here's a snapshot of a speed test I ran:
```console
❯ python -V
Python 3.11.5
```

#### Before
```console
❯ python -c "import time; start=time.perf_counter(); from pyLIMA.fits import TRF_fit; print(f'{time.perf_counter() - start:.2f}s')" 
1.19s
```

#### After
```console
❯ python -c "import time; start=time.perf_counter(); from pyLIMA.fits import TRF_fit; print(f'{time.perf_counter() - start:.2f}s')";
0.51s
```
