### PR TITLE
Update warning styling and links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ![Build Status](https://github.com/ebachelet/pyLIMA/actions/workflows/actions_unit_tests.yaml/badge.svg)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.997468.svg)](https://doi.org/10.5281/zenodo.997468)
 
-# Multiprocessing in pyLIMA (Warning)
-
-The latest version of pyLIMA applies the multiprocessing library to parallelize aspects of its model fitting processes in order to optimize for speed. This has been tested and works under Ubuntu Linux with Python 3.11.
-Users should be aware that the multiprocessing library uses a different method ('spawn') to start threads on the Mac and Windows platforms compared to the method used on Linux ('fork'), as the fork method is considered to be unsafe on these platforms. Unfortunately, this has meant that pyLIMA crashes if run under the latest version of Python (3.11) under a Mac (and likely under Windows), due to the outstanding issue with the multiprocessing library.
+> [!WARNING]
+> **Runing pyLIMA in multiprocessing...**
+> 
+> The latest version of pyLIMA applies the multiprocessing library to parallelize aspects of its model fitting processes in order to optimize for speed. This has been tested and works under Ubuntu Linux with Python 3.11.
+> Users should be aware that the multiprocessing library uses a different method ('spawn') to start threads on the Mac and Windows platforms compared to the method used on Linux ('fork'), as the fork method is considered to be unsafe on these platforms. Unfortunately, this has meant that pyLIMA crashes if run under the latest version of Python (3.11) under a Mac (and likely under Windows), due to the outstanding issue with the multiprocessing library.
 We are currently investigating a fix for this issue. In the interim we recommend using an earlier version of Python with the latest pyLIMA.
 
 # pyLIMA
@@ -60,4 +61,4 @@ Example_5 : [HOW TO FIT PARALLAX?](https://github.com/ebachelet/pyLIMA/tree/mast
 # How to contribute?
 
 Want to contribute? Bug detections? Comments?
-Please email us (etibachelet@gmail.com) or raise an issue (recommended).
+Please email us (etibachelet@gmail.com) or [raise an issue](https://github.com/ebachelet/pyLIMA/issues) (recommended).


### PR DESCRIPTION
Purely stylistic, updating the warning message at the top. 

![image](https://github.com/user-attachments/assets/bd1b4f15-c0b1-4263-8cdd-2bab3277faa2)

... also added a link in the text "raise issues".
