### PR TITLE
Add PyPI badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![Build Status](https://github.com/ebachelet/pyLIMA/actions/workflows/actions_unit_tests.yaml/badge.svg)
+[![PyPI](https://img.shields.io/pypi/v/pyLIMA)](https://pypi.org/project/pyLIMA/)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.997468.svg)](https://doi.org/10.5281/zenodo.997468)
+![Build Status](https://github.com/ebachelet/pyLIMA/actions/workflows/actions_unit_tests.yaml/badge.svg)
 
 > [!WARNING]
 > **Runing pyLIMA in multiprocessing...**


### PR DESCRIPTION
Adds this PyPI badge ![PyPI - Version](https://img.shields.io/pypi/v/pyLIMA)
 to the README. I always find myself not knowing which is the latest version of pyLIMA.

Badge generated by https://shields.io/badges

This website can generate many other badges if you wish to include them. Just visit each page posted on the side and fill out the form. Here's another example:

![PyPI - Downloads](https://img.shields.io/pypi/dm/pyLIMA)
