### PR TITLE
Add PyPI badget to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-![Build Status](https://github.com/ebachelet/pyLIMA/actions/workflows/actions_unit_tests.yaml/badge.svg)
+[![PyPI - Version](https://img.shields.io/pypi/v/pyLIMA.svg)](https://pypi.org/project/pyLIMA)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.997468.svg)](https://doi.org/10.5281/zenodo.997468)
+![Build Status](https://github.com/ebachelet/pyLIMA/actions/workflows/actions_unit_tests.yaml/badge.svg)
 
 > [!WARNING]
 > **Runing pyLIMA in multiprocessing...**


### PR DESCRIPTION
It's hard to tell what's the latest version of pyLIMA unless we link it directly to PyPI or use GitHub release page. This badge should help–

[![PyPI - Version](https://img.shields.io/pypi/v/pyLIMA.svg)](https://pypi.org/project/pyLIMA)
